### PR TITLE
Fix typos and improve testing

### DIFF
--- a/.github/workflows/nightly_cleanup.yml
+++ b/.github/workflows/nightly_cleanup.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: kolpav/purge-artifacts-action@04c636a505f26ebc82f8d070b202fb87ff572b10 # v1
         with:
-          token: $
+          token: ${{ secrets.GITHUB_TOKEN }}
           expire-in: 0

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -1,6 +1,6 @@
 name: "Build & Release Nightly"
 
-# This worflow needs those secrets:
+# This workflow needs those secrets:
 #
 # DOCKERPASSWORD = Docker Hub token
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: "Build & Release"
 
-# This worflow needs those secrets:
+# This workflow needs those secrets:
 #
 # DOCKERPASSWORD = Docker Hub token
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 *(see https://github.com/mxpv/podsync/issues/236 and https://github.com/mxpv/podsync/issues/237)*
 ## Quick reference
 
-This Repo is solely for me having a arm64 image for [Podsync](https://github.com/mxpv/podsync). It includes a GitHub Workflow to build Podsync for AMD64, ARM64, ARMv6 and ARMv7. Use it at your own risk. No warranty. No support.
+This Repo is solely for me having an arm64 image for [Podsync](https://github.com/mxpv/podsync). It includes a GitHub Workflow to build Podsync for AMD64, ARM64, ARMv6 and ARMv7. Use it at your own risk. No warranty. No support.
 
 Read here for more: https://github.com/mxpv/podsync/issues/56
 
@@ -26,7 +26,7 @@ Read here for more: https://github.com/mxpv/podsync/issues/56
 - There are tags for major, minor and dotreleases of podsync (eg. ```1.0.0```, ```1.0```, ```1``` )
 - ```latest``` refers to the latest release of podsync
 
-The images get rebuild automatically every week.
+The images get rebuilt automatically every week.
 ## Usage
 
 ```sh

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 cat <<EOF > /tmp/config.toml
 [server]


### PR DESCRIPTION
## Summary
- fix workflow comment typos
- set proper token in nightly cleanup workflow
- update README grammar
- make the test script fail fast

## Testing
- `bash -n test/test.sh`
- `bash test/test.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852643faf0c832c96c869a8ed210669